### PR TITLE
remove URI requirement on sub claim

### DIFF
--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -245,8 +245,8 @@ The following registered JWT claims MAY be contained in the SD-JWT or in the
 Disclosures and MAY be selectively disclosed:
 
 * `sub`
-    * OPTIONAL. The identifier of the Subject of the Verifiable Credential.
-The value of `sub` MUST be a URI. The Issuer MAY use it to provide the Subject
+    * OPTIONAL. The identifier of the Subject of the Verifiable Credential as known to the .
+The Issuer MAY use it to provide the Subject
 identifier known by the Issuer. There is no requirement for a binding to
 exist between `sub` and `cnf` claims.
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -245,7 +245,7 @@ The following registered JWT claims MAY be contained in the SD-JWT or in the
 Disclosures and MAY be selectively disclosed:
 
 * `sub`
-    * OPTIONAL. The identifier of the Subject of the Verifiable Credential as known to the .
+    * OPTIONAL. The identifier of the Subject of the Verifiable Credential.
 The Issuer MAY use it to provide the Subject
 identifier known by the Issuer. There is no requirement for a binding to
 exist between `sub` and `cnf` claims.


### PR DESCRIPTION
I don't think there is a need to constraint the `sub` claim value to be a URI. 