### PR TITLE
first pass at positioning jwt vc as an sd-jwt vc without selectively disclosable claims

### DIFF
--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -32,7 +32,7 @@ organization="Authlete Inc. "
 
 This specification describes data formats as well as validation and processing
 rules to express Verifiable Credentials based on the Selective Disclosure
-for JWT (SD-JWT) [@!I-D.ietf-oauth-selective-disclosure-jwt] format.
+for JWTs (SD-JWT) [@!I-D.ietf-oauth-selective-disclosure-jwt] format.
 It can be used when there are no selective disclosable claims, too.
 
 {mainmatter}

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -98,20 +98,18 @@ a specification that introduces conventions to support selective disclosure for
 JWTs: For an SD-JWT document, a Holder can decide which claims to release (within
 bounds defined by the Issuer).
 
-SD-JWT itself does not define the claims that must be used within the payload or
-their semantics. SD-JWT can be used when there are no selectively disclosable claims.
-This specification therefore defines how Verifiable Credentials
-can be expressed using SD-JWT.
+SD-JWT is a superset of JWT as it can also be used when there are no selectively
+disclosable claims and also supports JWS JSON serialization, which is useful for
+long term archiving and multi signatures. However, SD-JWT itself does not define
+the claims that must be used within the payload or their semantics.
 
-JWTs (and SD-JWTs) can contain claims that are registered in "JSON Web Token Claims"
+This specification therefore uses SD-JWT and the well-established JWT content rules and
+extensibility model as basis for representing Verifiable Credentials with JSON payload.
+Those Verifiable Credentials are called SD-JWT VCs.
+
+SD-JWTs VC can contain claims that are registered in "JSON Web Token Claims"
 registry as defined in [@!RFC7519], as well as public and
-private claims. Private claims are not relevant for this specification due to the
-openness of the three-party-model. Since SD-JWTs are based on JWTs, this specification
-aims to express the basic
-Verifiable Credential data model purely through JWT Claim Sets, using registered
-claims while allowing Issuers to use additional registered claims, as well as
-new or existing public claims, to make statements about the Subject of the
-Verifiable Credential.
+private claims.
 
 ## Requirements Notation and Conventions
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -253,10 +253,10 @@ exist between `sub` and `cnf` claims.
 Additional public claims MAY be used in SD-JWT VCs depending on the
 application.
 
-#### SD-JWT VC without selectively disclosable claims
+#### SD-JWT VC without Selectively Disclosable Claims
 
-SD-JWT VC may not contain any selectively disclosable claims.
-In that case, the SD-JWT VC MUST NOT contain the `_sd` claim in the JWT body. I also
+An SD-JWT VC MAY have no selectively disclosable claims.
+In that case, the SD-JWT VC MUST NOT contain the `_sd` claim in the JWT body. It also
 MUST NOT have any Disclosures.
 
 ## Example
@@ -572,10 +572,20 @@ Interoperability considerations: : n/a
 
 # Acknowledgements {#Acknowledgements}
 
-We would like to thank Alen Horvat, Andres Uribe, Brian Campbell, Christian Bormann,
-Giuseppe De Marco, Michael Jones, Mike Prorock, Orie Steele, Paul Bastian,
-Torsten Lodderstedt, Tobias Looker and Kristina Yasuda for their contributions
-(some of which substantial) to this draft and to the initial set of implementations.
+We would like to thank
+Alen Horvat,
+Andres Uribe,
+Brian Campbell,
+Christian Bormann,
+Giuseppe De Marco,
+Michael Jones,
+Mike Prorock,
+Orie Steele,
+Paul Bastian,
+Torsten Lodderstedt,
+Tobias Looker, and
+Kristina Yasuda
+for their contributions (some of which substantial) to this draft and to the initial set of implementations.
 
 # Document History
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -294,8 +294,8 @@ verification, the `iss` claim in the SD-JWT MAY be used to retrieve the public
 key from the JWT Issuer Metadata configuration (as defined in
 (#jwt-issuer-metadata)) of the SD-JWT VC issuer. A Verifier MAY use alternative
 methods to obtain the public key to verify the signature of the SD-JWT.
-If there are no selectively disclosable claims, there is no need to process
-`_sd` claim nor Disclosures.
+If there are no selectively disclosable claims, there is no need to process the
+`_sd` claim nor any Disclosures.
  1. OPTIONAL. If `status` is present in the verified payload of the SD-JWT,
 the status SHOULD be checked. It depends on the Verifier policy to reject or
 accept a presentation of a SD-JWT VC based on the status of the Verifiable
@@ -433,7 +433,7 @@ A presentation of an SD-JWT VC MAY contain a Holder Binding JWT as described in
 Section 5.4.1. of [@!I-D.ietf-oauth-selective-disclosure-jwt].
 
 When there are no selectively disclosable claims, a presentation of SD-JWT VC
-does not contain any disclosures.
+does not contain any Disclosures.
 
 ### Holder Binding JWT
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -31,7 +31,7 @@ organization="Authlete Inc. "
 .# Abstract
 
 This specification describes data formats as well as validation and processing
-rules to express Verifiable Credentials based on the Selective Disclosure
+rules to express Verifiable Credentials with JSON payloads based on the Selective Disclosure
 for JWTs (SD-JWT) [@!I-D.ietf-oauth-selective-disclosure-jwt] format.
 It can be used when there are no selective disclosable claims, too.
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -31,8 +31,9 @@ organization="Authlete Inc. "
 .# Abstract
 
 This specification describes data formats as well as validation and processing
-rules to express Verifiable Credentials with JSON payload based on the SD-JWT
-format [@!I-D.ietf-oauth-selective-disclosure-jwt].
+rules to express Verifiable Credentials based on the Selective Disclosure
+for JWT and JWS with JSON payloads (SD-JWT) format [@!I-D.ietf-oauth-selective-disclosure-jwt].
+It can be used when there are no selective disclosable claims, too.
 
 {mainmatter}
 
@@ -84,25 +85,22 @@ involved, a Status Provider, who delivers revocation information to Verifiers.
 (The Verifier can also serve as the Status Provider.)
 
 This specification defines Verifiable Credentials based on the SD-JWT
-format with a JWT Claim Set.
+format with a JWT Claim Set. It can be used when there are no selective disclosable claims, too.
 
 ## Rationale
 
 JSON Web Tokens (JWTs) [@!RFC7519] can in principle be used to express
 Verifiable Credentials in a way that is easy to understand and process as it
-builds upon established web primitives. While JWT-based credentials enable selective
-disclosure, i.e., the ability for a Holder to disclose only a subset of the contained
-claims, in an Identity Provider ecosystem by issuing new JWTs to the Verifier for
-every presentation, this approach does not work in the three-party-model.
+builds upon established web primitives.
 
 Selective Disclosure JWT (SD-JWT) [@!I-D.ietf-oauth-selective-disclosure-jwt] is
 a specification that introduces conventions to support selective disclosure for
 JWTs: For an SD-JWT document, a Holder can decide which claims to release (within
-bounds defined by the Issuer). This format is therefore perfectly suited for
-Verifiable Credentials.
+bounds defined by the Issuer).
 
 SD-JWT itself does not define the claims that must be used within the payload or
-their semantics. This specification therefore defines how Verifiable Credentials
+their semantics. SD-JWT can be used when there are no selectively disclosable claims.
+This specification therefore defines how Verifiable Credentials
 can be expressed using SD-JWT.
 
 JWTs (and SD-JWTs) can contain claims that are registered in "JSON Web Token Claims"
@@ -131,7 +129,8 @@ Verifiable Credential (VC):
 
 SD-JWT-based Verifiable Credential (SD-JWT VC):
 : A Verifiable Credential encoded using the Issuance format defined in
-[@!I-D.ietf-oauth-selective-disclosure-jwt].
+[@!I-D.ietf-oauth-selective-disclosure-jwt]. It may or may not contain
+selectively disclosable claims.
 
 Unsecured payload of an SD-JWT VC:
 : A JSON object containing all selectively disclosable and non-selectively disclosable claims
@@ -168,7 +167,8 @@ SD-JWT VCs compliant with this specification MUST use the media type
 SD-JWT VCs MUST be encoded using the SD-JWT Combined Format for Issuance as
 defined in Section 5.3. of [@!I-D.ietf-oauth-selective-disclosure-jwt].
 
-SD-JWT VCs MUST contain all Disclosures corresponding to their SD-JWT component
+When there are selectively disclosable claims, SD-JWT VCs MUST contain all
+Disclosures corresponding to their SD-JWT component
 except for Decoy Digests as per Section 5.1.1.3. of [@!I-D.ietf-oauth-selective-disclosure-jwt].
 
 ### Header Parameters
@@ -255,6 +255,12 @@ exist between `sub` and `cnf` claims.
 Additional public claims MAY be used in SD-JWT VCs depending on the
 application.
 
+#### SD-JWT VC without selectively disclosable claims
+
+SD-JWT VC may not contain any selectively disclosable claims.
+Such SD-JWT VC does not contain `_sd` claim in the JWT body and
+does not have any Disclosures.
+
 ## Example
 
 The following is a non-normative example of an unsecured payload of an
@@ -290,6 +296,8 @@ verification, the `iss` claim in the SD-JWT MAY be used to retrieve the public
 key from the JWT Issuer Metadata configuration (as defined in
 (#jwt-issuer-metadata)) of the SD-JWT VC issuer. A Verifier MAY use alternative
 methods to obtain the public key to verify the signature of the SD-JWT.
+If there are no selectively disclosable claims, there is no need to process
+`_sd` claim nor Disclosures.
  1. OPTIONAL. If `status` is present in the verified payload of the SD-JWT,
 the status SHOULD be checked. It depends on the Verifier policy to reject or
 accept a presentation of a SD-JWT VC based on the status of the Verifiable
@@ -425,6 +433,9 @@ Format for Presentation as defined in Section 5.4. of
 
 A presentation of an SD-JWT VC MAY contain a Holder Binding JWT as described in
 Section 5.4.1. of [@!I-D.ietf-oauth-selective-disclosure-jwt].
+
+When there are no selectively disclosable claims, a presentation of SD-JWT VC
+does not contain any disclosures.
 
 ### Holder Binding JWT
 
@@ -563,12 +574,16 @@ Interoperability considerations: : n/a
 
 # Acknowledgements {#Acknowledgements}
 
-We would like to thank Alen Horvat, Andres Uribe, Christian Bormann,
-Giuseppe De Marco, Paul Bastian, Torsten Lodderstedt, Tobias Looker
-and Kristina Yasuda for their contributions (some of which substantial) to this
-draft and to the initial set of implementations.
+We would like to thank Alen Horvat, Andres Uribe, Brian Campbell, Christian Bormann,
+Giuseppe De Marco, Michael Jones, Mike Prorock, Orie Steele, Paul Bastian,
+Torsten Lodderstedt, Tobias Looker and Kristina Yasuda for their contributions
+(some of which substantial) to this draft and to the initial set of implementations.
 
 # Document History
+
+-03
+
+* added non-selectively disclosable JWT VC
 
 -02
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -256,8 +256,8 @@ application.
 #### SD-JWT VC without selectively disclosable claims
 
 SD-JWT VC may not contain any selectively disclosable claims.
-Such SD-JWT VC does not contain `_sd` claim in the JWT body and
-does not have any Disclosures.
+In that case, the SD-JWT VC MUST NOT contain the `_sd` claim in the JWT body. I also
+MUST NOT have any Disclosures.
 
 ## Example
 

--- a/draft-terbu-sd-jwt-vc.md
+++ b/draft-terbu-sd-jwt-vc.md
@@ -32,7 +32,7 @@ organization="Authlete Inc. "
 
 This specification describes data formats as well as validation and processing
 rules to express Verifiable Credentials based on the Selective Disclosure
-for JWT and JWS with JSON payloads (SD-JWT) format [@!I-D.ietf-oauth-selective-disclosure-jwt].
+for JWT (SD-JWT) [@!I-D.ietf-oauth-selective-disclosure-jwt] format.
 It can be used when there are no selective disclosable claims, too.
 
 {mainmatter}


### PR DESCRIPTION
alternative to #120 based on @bc-pi 's comment "I can't help but wonder if it'd make sense to have the spec be only about SD-JWT VCs and treat the plain JWT VC as just a special case of an SD-JWT with no selectively disclosable claims."

no changes to the basic structure. simple clarifications what to do when there are no selectively disclosable claims ie no `_sd` claim and no Disclosures. Might need some more details but this is how it might look like.

(cc @OR13, @mprorock)

[linked to rendered preview](https://vcstuff.github.io/draft-terbu-sd-jwt-vc/jwt-vc-2/draft-terbu-sd-jwt-vc.html
)